### PR TITLE
Remove duplicated source attributes in cookbook_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the ntp cookbook.
 
 ## Unreleased
 
+- Remove duplicated source attributes in cookbook_file for leapfile_url
+
 ## 3.9.0 - *2021-01-29*
 
 - Sous Chefs Adoption

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -132,5 +132,5 @@ when 'pld'
 end
 
 default['ntp']['use_cmos'] = !node['virtualization'] || node['virtualization']['role'] != 'guest' ? true : false
-default['ntp']['leapfile_url'] = nil
+default['ntp']['leapfile_url'] = 'ntp.leapseconds'
 default['ntp']['leapfile_from_mirror'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,7 +83,6 @@ else
       owner node['ntp']['conf_owner']
       group node['ntp']['conf_group']
       mode '0644'
-      source 'ntp.leapseconds'
       source node['ntp']['leapfile_url']
       notifies :restart, "service[#{node['ntp']['service']}]"
     end


### PR DESCRIPTION
* The resource using the leapseconds file as cookbook_file had two
  sources
* It is confusing and incorrect since in this case the leapfile_url is
  probably nil

### Description
It fixes an error when not using the leapfile from a mirror

### Issues Resolved
https://github.com/chef-cookbooks/ntp/issues/197

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>