### PR TITLE
Add in ACi support in ntp.conf #207

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ This file is used to list changes made in each version of the ntp cookbook.
 
 ## Unreleased
 
-## 3.11.1 - *2021-11-08*
-
 - Updates the ntp.conf template to allow setting `dscp` value; This is to support Cisco Application Centric Infrastructure (ACI) for RedHat
 - Value is set to `nil` as this will only be set for `ACI` networks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is used to list changes made in each version of the ntp cookbook.
 
 ## Unreleased
 
+## 3.11.1 - *2021-11-08*
+
+- Updates the ntp.conf template to allow setting `dscp` value; This is to support Cisco Application Centric Infrastructure (ACI) for RedHat
+- Value is set to `nil` as this will only be set for `ACI` networks.
+
 ## 3.11.0 - *2021-10-14*
 
 - Updates the ntp.conf template to allow setting `tos maxdist` value; helpful when ntpd uses a remote Windows server as a time source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ This file is used to list changes made in each version of the ntp cookbook.
 
 ## Unreleased
 
-- Updates the ntp.conf template to allow setting `dscp` value; This is to support Cisco Application Centric Infrastructure (ACI) for RedHat
-- Value is set to `nil` as this will only be set for `ACI` networks.
+- Updates the ntp.conf template to allow setting `dscp` value; This is to support Cisco Application Centric Infrastructure (ACI) for RedHat.
+- Value is set to `nil`, as this will only be set if you require Differentiated Services Control Point (DSCP).
 
 ## 3.11.0 - *2021-10-14*
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 - `ntp['dscp']`
 
   - Number. Default is set to `nil`, This option specifies the Differentiated Services Control Point (DSCP) value, a 6-bit code. The default value is 46, signifying Expedited Forwarding.
+  - This is to support Cisco Application Centric Infrastructure (ACI).
 
 ### Automatically Set Attributes
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
   - Number. Defaults to 5, recommended value for stratum is 2 more than the worst-case externally-reachable source of time
 
-- `ntp['aci_support']`
+- `ntp['dscp']`
 
   - Number. Default is set to `nil`, as not all networks are running `ACI` recommended value is `46` as per `RedHat`. Check with your vendor `Cisco` to be sure.
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 - `ntp['dscp']`
 
-  - Number. Default is set to `nil`, as not all networks are running `ACI` recommended value is `46` as per `RedHat`. Check with your vendor `Cisco` to be sure.
+  - Number. Default is set to `nil`, This option specifies the Differentiated Services Control Point (DSCP) value, a 6-bit code. The default value is 46, signifying Expedited Forwarding.
 
 ### Automatically Set Attributes
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
   - Number. Defaults to 5, recommended value for stratum is 2 more than the worst-case externally-reachable source of time
 
+- `ntp['aci_support']`
+
+  - Number. Default is set to `nil`, as not all networks are running `ACI` recommended value is `46` as per `RedHat`. Check with your vendor `Cisco` to be sure.
+
 ### Automatically Set Attributes
 
 These attributes are set based on platform / system information provided by Ohai

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,6 +57,7 @@ default['ntp']['conf_restart_immediate'] = false
 default['ntp']['keys'] = nil
 default['ntp']['trustedkey'] = nil
 default['ntp']['requestkey'] = nil
+default['ntp']['aci_support'] = nil
 
 # See http://www.vmware.com/vmtn/resources/238 p. 23 for explanation
 default['ntp']['disable_tinker_panic_on_virtualization_guest'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,7 +57,7 @@ default['ntp']['conf_restart_immediate'] = false
 default['ntp']['keys'] = nil
 default['ntp']['trustedkey'] = nil
 default['ntp']['requestkey'] = nil
-default['ntp']['aci_support'] = nil
+default['ntp']['dscp'] = nil
 
 # See http://www.vmware.com/vmtn/resources/238 p. 23 for explanation
 default['ntp']['disable_tinker_panic_on_virtualization_guest'] = true

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -101,8 +101,8 @@ describe 'ntp attributes' do
       expect(ntp['trustedkey']).to be nil
     end
 
-    it 'sets the aci_support to nil' do
-      expect(ntp['aci_support']).to be nil
+    it 'sets the dscp to nil' do
+      expect(ntp['dscp']).to be nil
     end
 
     it 'sets conf_restart_immediate to false' do

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -101,6 +101,10 @@ describe 'ntp attributes' do
       expect(ntp['trustedkey']).to be nil
     end
 
+    it 'sets the aci_support to nil' do
+      expect(ntp['aci_support']).to be nil
+    end
+
     it 'sets conf_restart_immediate to false' do
       expect(ntp['conf_restart_immediate']).to eq(false)
     end

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -110,3 +110,6 @@ trustedkey <%= node['ntp']['trustedkey'] %>
 <% if node['ntp']['requestkey'] -%>
 requestkey <%= node['ntp']['requestkey'] %>
 <% end -%>
+<% if node['ntp']['aci_support'] -%>
+dscp <%= node['ntp']['aci_support'] %>
+<% end -%>

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -110,6 +110,6 @@ trustedkey <%= node['ntp']['trustedkey'] %>
 <% if node['ntp']['requestkey'] -%>
 requestkey <%= node['ntp']['requestkey'] %>
 <% end -%>
-<% if node['ntp']['aci_support'] -%>
-dscp <%= node['ntp']['aci_support'] %>
+<% if node['ntp']['dscp'] -%>
+dscp <%= node['ntp']['dscp'] %>
 <% end -%>


### PR DESCRIPTION
# Description

This adds in the DSCP value for ACI network support.

## Issues Resolved

issue #207 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
