### PR TITLE
GH-250

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Standardise files with files in sous-chefs/repo-management
 
 Standardise files with files in sous-chefs/repo-management
 
+Added capability to set logconfig using an attribute
+
 ## 5.1.2 - *2024-05-02*
 
 ## 5.1.1 - *2024-05-02*

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,6 +38,7 @@ default['ntp']['service'] = 'ntpd'
 default['ntp']['varlibdir'] = '/var/lib/ntp'
 default['ntp']['driftfile'] = "#{node['ntp']['varlibdir']}/ntp.drift"
 default['ntp']['logfile'] = nil
+default['ntp']['logconfig'] = 'all'
 default['ntp']['conffile'] = '/etc/ntp.conf'
 default['ntp']['statsdir'] = '/var/log/ntpstats/'
 default['ntp']['conf_owner'] = 'root'

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -49,6 +49,10 @@ describe 'ntp attributes' do
       expect(ntp['logfile']).to be nil
     end
 
+    it 'sets the logconfig to all' do
+      expect(ntp['logconfig']).to eq('all')
+    end
+
     it 'sets the conf file to /etc/ntp.conf' do
       expect(ntp['conffile']).to eq('/etc/ntp.conf')
     end

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -43,6 +43,10 @@ interface listen 127.0.0.1
 <%   end -%>
 <% end -%>
 
+<% unless node['ntp']['logconfig'].nil? -%>
+logconfig =<%= node['ntp']['logconfig'] %>
+<% end -%>
+
 <% if node['ntp']['monitor'] -%>
 enable monitor
 <% else -%>


### PR DESCRIPTION
Added capability to set logconfig using an attribute

# Description

A user of the ntp cookbook can set the attribute ['ntp']['logconfig'] which will in turn add the line:
`logconfig =<value>`
to the ntp.conf file. This allows a user to custom-configure the verbosity of their ntp logging

## Issues Resolved

- GH-250

## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable.
