### PR TITLE
Make ntpsec use a compatible Apparmor configuration (#257)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,8 @@ default['ntp']['conf_group'] = 'root'
 if platform?('debian') && node['platform_version'].to_i >= 12
   default['ntp']['var_owner'] = 'ntpsec'
   default['ntp']['var_group'] = 'ntpsec'
+  default['ntp']['conffile'] = '/etc/ntpsec/ntp.conf'
+  default['ntp']['statsdir'] = '/var/log/ntpsec/'
 else
   default['ntp']['var_owner'] = 'ntp'
   default['ntp']['var_group'] = 'ntp'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,7 +44,7 @@ default['ntp']['statsdir'] = '/var/log/ntpstats/'
 default['ntp']['conf_owner'] = 'root'
 default['ntp']['conf_group'] = 'root'
 
-if platform?('debian') && node['platform_version'].to_i >= 12
+if (platform?('debian') && node['platform_version'].to_i >= 12) || (platform?('ubuntu') && node['platform_version'].gsub('.', '').to_i >= 2310)
   default['ntp']['var_owner'] = 'ntpsec'
   default['ntp']['var_group'] = 'ntpsec'
   default['ntp']['conffile'] = '/etc/ntpsec/ntp.conf'

--- a/files/usr.sbin.ntpsec.apparmor
+++ b/files/usr.sbin.ntpsec.apparmor
@@ -1,0 +1,90 @@
+# vim:syntax=apparmor
+#
+# Maintained by Chef
+#
+# Updated for Ubuntu by: Jamie Strandboge <jamie@canonical.com>
+# ------------------------------------------------------------------
+#
+#    Copyright (C) 2002-2005 Novell/SUSE
+#    Copyright (C) 2009-2012 Canonical Ltd.
+#
+#    This program is free software; you can redistribute it and/or
+#    modify it under the terms of version 2 of the GNU General Public
+#    License published by the Free Software Foundation.
+#
+# ------------------------------------------------------------------
+
+#include <tunables/global>
+#include <tunables/ntpd>
+/usr/sbin/ntpd flags=(attach_disconnected) {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/openssl>
+  #include <abstractions/user-tmp>
+
+  capability ipc_lock,
+  capability net_admin,
+  capability net_bind_service,
+  capability setgid,
+  capability setuid,
+  capability sys_chroot,
+  capability sys_resource,
+  capability sys_time,
+  capability sys_nice,
+
+  # ntp uses AF_INET, AF_INET6 and AF_UNSPEC
+  network dgram,
+  network stream,
+
+  @{PROC}/net/if_inet6 r,
+  @{PROC}/*/net/if_inet6 r,
+  @{NTPD_DEVICE} rw,
+  # pps devices are almost exclusively used with NTP
+  /dev/pps[0-9]* rw,
+
+  /{,s}bin/      r,
+  /usr/{,s}bin/  r,
+  /usr/local/{,s}bin/  r,
+  /usr/sbin/ntpd rmix,
+
+  /etc/ntpsec/ntp.conf r,
+  /etc/ntpsec/ntp.d/ r,
+  /etc/ntpsec/ntp.d/*.conf r,
+  /run/ntpsec/ntp.conf.dhcp r,
+
+  /etc/ntpsec/cert-chain.pem r,
+  /etc/ntpsec/key.pem r,
+  /etc/ntpsec/ntp.keys r,
+
+  /var/lib/ntpsec/ntp.drift rw,
+  /var/lib/ntpsec/ntp.drift-tmp rw,
+  /var/lib/ntpsec/nts-keys rw,
+  /usr/share/zoneinfo/leap-seconds.list rw,
+
+  /var/log/ntp w,
+  /var/log/ntp.log w,
+  /var/log/ntpd w,
+  /var/log/ntpsec/clockstats* rwl,
+  /var/log/ntpsec/loopstats*  rwl,
+  /var/log/ntpsec/peerstats*  rwl,
+  /var/log/ntpsec/protostats* rwl,
+  /var/log/ntpsec/rawstats*   rwl,
+  /var/log/ntpsec/sysstats*   rwl,
+
+  /{,var/}run/ntpd.pid w,
+
+  # to be able to check for running ntpdate
+  /run/lock/ntpsec-ntpdate wk,
+
+  # To sign replies to MS-SNTP clients by the smbd daemon /var/lib/samba
+  /var/lib/samba/ntp_signd/socket rw,
+
+  # For use with clocks that report via shared memory (e.g. gpsd),
+  # you may need to give ntpd access to all of shared memory, though
+  # this can be considered dangerous. See https://launchpad.net/bugs/722815
+  # for details. To enable, add this to local/usr.sbin.ntpd:
+  #     capability ipc_owner,
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/usr.sbin.ntpd>
+}

--- a/recipes/apparmor.rb
+++ b/recipes/apparmor.rb
@@ -21,8 +21,14 @@ service 'apparmor' do
   action :nothing
 end
 
+apparmor_source = if node['ntp']['var_owner'] == 'ntpsec'
+                    'usr.sbin.ntpsec.apparmor'
+                  else
+                    'usr.sbin.ntpd.apparmor'
+                  end
+
 cookbook_file '/etc/apparmor.d/usr.sbin.ntpd' do
-  source 'usr.sbin.ntpd.apparmor'
+  source apparmor_source
   owner 'root'
   group 'root'
   mode '0644'

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -23,12 +23,20 @@ elsif os.family == 'redhat' && os.release.to_i < 8
   describe file '/usr/share/zoneinfo/leapseconds' do
     it { should be_file }
   end
-elsif os.family == 'debian' && os.release.to_i <= 11
+elsif os.name == 'debian' && os.release.to_i <= 11
   describe file '/etc/ntp.conf' do
     it { should be_file }
   end
-elsif os.family == 'debian' && os.release.to_i >= 12
+elsif os.name == 'debian' && os.release.to_i >= 12
   describe file '/etc/ntpsec/ntp.conf' do
+    it { should be_file }
+  end
+elsif os.name == 'ubuntu' && os.release.to_i >= 2310
+  describe file '/etc/ntpsec/ntp.conf' do
+    it { should be_file }
+  end
+elsif os.name == 'ubuntu' && os.release.to_i < 2310
+  describe file '/etc/ntp.conf' do
     it { should be_file }
   end
 

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -23,8 +23,12 @@ elsif os.family == 'redhat' && os.release.to_i < 8
   describe file '/usr/share/zoneinfo/leapseconds' do
     it { should be_file }
   end
-elsif os.family == 'debian'
+elsif os.family == 'debian' && os.release.to_i <= 11
   describe file '/etc/ntp.conf' do
+    it { should be_file }
+  end
+elsif os.family == 'debian' && os.release.to_i >= 12
+  describe file '/etc/ntpsec/ntp.conf' do
     it { should be_file }
   end
 

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -31,12 +31,12 @@ elsif os.name == 'debian' && os.release.to_i >= 12
   describe file '/etc/ntpsec/ntp.conf' do
     it { should be_file }
   end
-elsif os.name == 'ubuntu' && os.release.to_i >= 2310
-  describe file '/etc/ntpsec/ntp.conf' do
+elsif os.name == 'ubuntu' && os.release.gsub('.', '').to_i < 2310
+  describe file '/etc/ntp.conf' do
     it { should be_file }
   end
-elsif os.name == 'ubuntu' && os.release.to_i < 2310
-  describe file '/etc/ntp.conf' do
+elsif os.name == 'ubuntu' && os.release.gsub('.', '').to_i >= 23.10
+  describe file '/etc/ntpsec/ntp.conf' do
     it { should be_file }
   end
 


### PR DESCRIPTION
# Description

Introduces a ntpsec compatible Apparmor configuration, and uses it.

## Issues Resolved

#257 but it could help for #254 .

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
